### PR TITLE
Add dependency checker

### DIFF
--- a/LspdfrBasePlugin/LspdfrBasePlugin.csproj
+++ b/LspdfrBasePlugin/LspdfrBasePlugin.csproj
@@ -53,6 +53,7 @@
     <Compile Include="EntryPoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="Util\DependencyChecker.cs" />
     <Compile Include="Util\VersionCheck.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LspdfrBasePlugin/Util/DependencyChecker.cs
+++ b/LspdfrBasePlugin/Util/DependencyChecker.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+
+namespace LspdfrBasePlugin.Util
+{
+    /// <summary>
+    /// Rage refers to files in the \Plugins folder, LSPDFR refers to files in the \Plugins\LSPDFR folder, and Game refers to files in the root GTA folder
+    /// </summary>
+    enum PluginType
+    { 
+        Rage,
+        LSPDFR,
+        Game
+    }
+    
+    internal class DependencyChecker
+    {
+        /// <summary>
+        /// Checks if a .dll file with the given <paramref name="fileName"/> is found in the correct directory based on the specified <paramref name="pluginType"/>
+        /// </summary>
+        /// <param name="pluginType">PluginType.Rage checks \Plugins, PluginType.LSPDFR checks \Plugins\LSPDFR, and PluginType.Game checks the root GTA folder</param>
+        /// <param name="fileName">The name (case-insensitive and without extension) of the .dll file.</param>
+        internal static bool IsDependencyPresent(PluginType pluginType, string fileName)
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+            switch (pluginType)
+            { 
+                case PluginType.Rage:
+                    currentDirectory += @"\Plugins";
+                    break;
+                case PluginType.LSPDFR:
+                    currentDirectory += @"\Plugins\LSPDFR";
+                    break;
+            }
+
+            return File.Exists($"{currentDirectory}\\{fileName}.dll");
+        }
+    }
+}

--- a/LspdfrBasePlugin/Util/DependencyChecker.cs
+++ b/LspdfrBasePlugin/Util/DependencyChecker.cs
@@ -15,11 +15,12 @@ namespace LspdfrBasePlugin.Util
     internal class DependencyChecker
     {
         /// <summary>
-        /// Checks if a .dll file with the given <paramref name="fileName"/> is found in the correct directory based on the specified <paramref name="pluginType"/>
+        /// Checks if a file with the given <paramref name="fileName"/> is found in the correct directory based on the specified <paramref name="pluginType"/>
         /// </summary>
         /// <param name="pluginType">PluginType.Rage checks \Plugins, PluginType.LSPDFR checks \Plugins\LSPDFR, and PluginType.Game checks the root GTA folder</param>
-        /// <param name="fileName">The name (case-insensitive and without extension) of the .dll file.</param>
-        internal static bool IsDependencyPresent(PluginType pluginType, string fileName)
+        /// <param name="fileName">The name (case-insensitive and without extension) of the file.</param>
+        /// <param name="fileExtension">The file extension of the dependency being checked.  dll by default</param>
+        internal static bool IsDependencyPresent(PluginType pluginType, string fileName, string fileExtension = "dll")
         {
             var currentDirectory = Directory.GetCurrentDirectory();
             switch (pluginType)
@@ -32,7 +33,7 @@ namespace LspdfrBasePlugin.Util
                     break;
             }
 
-            return File.Exists($"{currentDirectory}\\{fileName}.dll");
+            return File.Exists($"{currentDirectory}\\{fileName}.{fileExtension}");
         }
     }
 }


### PR DESCRIPTION
Provides a class with a simple method for checking if a .dll file with the given name is found in the correct directory based on the specified plugin type.